### PR TITLE
Linux PGO build scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,3 +73,25 @@ Tested on a Ryzen 7 4600U
 * n = 19 3d rotation: `27144143923583`
 
 * n = 19 4d rotation: `13573319825615`
+
+## Compiling with Profile Guided Optimization (thanks @HakMe2Deth)
+
+First, install ```llvm-profdata``` through rustup:
+
+```
+rustup component add llvm-tools-preview
+```
+
+Then run the build script for the main binary or the client:
+
+```
+./build-pgo.sh
+```
+
+```
+./client-build-pgo.sh
+```
+
+This has only been tested on linux on x86_64. On my machine, I get a ~15% performance boost compared to building normally, but your mileage may vary
+
+For windows, see #1

--- a/README.md
+++ b/README.md
@@ -94,4 +94,4 @@ Then run the build script for the main binary or the client:
 
 This has only been tested on linux on x86_64. On my machine, I get a ~15% performance boost compared to building normally, but your mileage may vary
 
-For windows, see #1
+For windows, see this [issue](https://github.com/pbj4/polycubes/issues/1)

--- a/build-pgo.sh
+++ b/build-pgo.sh
@@ -1,7 +1,9 @@
 #!/bin/bash
 set -e
 
-tmpdir=$(mktemp -d)
+tmpdir="$(pwd)/target/pgo-data/"
+rm -rf "$tmpdir"
+mkdir -p "$tmpdir"
 target=$(rustc -vV | sed -n 's|host: ||p')
 EXTRA_RUSTFLAGS="--C target-cpu=native --C opt-level=3 --C lto=yes --C embed-bitcode=y --C codegen-units=1 --C code-model=small --C debuginfo=0"
 
@@ -21,9 +23,6 @@ echo "Merging profiles..."
 
 echo "Building optimized binary..."
 RUSTFLAGS="-Cprofile-use=$tmpdir/merged.profdata $EXTRA_RUSTFLAGS" cargo build --release --target=$target
-
-echo "Removing temporary directory..."
-rm -rf "$tmpdir"
 
 echo "Finished"
 echo "Run optimized binary with \`./target/$target/release/polycubes\`"

--- a/build-pgo.sh
+++ b/build-pgo.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+set -e
+
+tmpdir=$(mktemp -d)
+target=$(rustc -vV | sed -n 's|host: ||p')
+EXTRA_RUSTFLAGS="--C target-cpu=native --C opt-level=3 --C lto=yes --C embed-bitcode=y --C codegen-units=1 --C code-model=small --C debuginfo=0"
+
+echo "Target: $target"
+echo "Using $tmpdir as temporary directory"
+
+echo "Building instrumented binary..."
+RUSTFLAGS="-Cprofile-generate=$tmpdir $EXTRA_RUSTFLAGS" cargo build --release --target=$target
+
+echo "Gathering profiles..."
+./target/$target/release/polycubes 10
+./target/$target/release/polycubes 11
+./target/$target/release/polycubes 12
+
+echo "Merging profiles..."
+~/.rustup/toolchains/stable-$target/lib/rustlib/$target/bin/llvm-profdata merge -o "$tmpdir/merged.profdata" "$tmpdir"
+
+echo "Building optimized binary..."
+RUSTFLAGS="-Cprofile-use=$tmpdir/merged.profdata $EXTRA_RUSTFLAGS" cargo build --release --target=$target
+
+echo "Removing temporary directory..."
+rm -rf "$tmpdir"
+
+echo "Finished"
+echo "Run optimized binary with \`./target/$target/release/polycubes\`"

--- a/client-build-pgo.sh
+++ b/client-build-pgo.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+set -e
+
+tmpdir=$(mktemp -d)
+target=$(rustc -vV | sed -n 's|host: ||p')
+EXTRA_RUSTFLAGS="--C target-cpu=native --C opt-level=3 --C lto=yes --C embed-bitcode=y --C codegen-units=1 --C code-model=small --C debuginfo=0"
+
+echo "Target: $target"
+echo "Using $tmpdir as temporary directory"
+
+echo "Building instrumented client..."
+RUSTFLAGS="-Cprofile-generate=$tmpdir $EXTRA_RUSTFLAGS" cargo build --release --target=$target --bin client --features client
+
+echo "Building server..."
+cargo build -r --bin server --features server
+
+echo "Gathering profiles..."
+
+function test(){
+    rm -rf serverdb
+    ./target/release/server 127.0.0.1:48479 1 $1 &
+    local serverpid="$!"
+    sleep 1
+    ./target/$target/release/client http://127.0.0.1:48479/
+    kill $serverpid
+}
+
+test 10
+test 11
+test 12
+
+echo "Merging profiles..."
+~/.rustup/toolchains/stable-$target/lib/rustlib/$target/bin/llvm-profdata merge -o "$tmpdir/merged.profdata" "$tmpdir"
+
+echo "Building optimized client..."
+RUSTFLAGS="-Cprofile-use=$tmpdir/merged.profdata $EXTRA_RUSTFLAGS" cargo build --release --target=$target --bin client --features client
+
+echo "Removing temporary directory..."
+rm -rf "$tmpdir"
+
+echo "Finished"
+echo "Run optimized client with \`./target/$target/release/client\`"


### PR DESCRIPTION
Adds build scripts for the main binary and client worker and associated documentation, adapted from the linux PGO guide in #1 by @HakMe2Deth

Some modifications:
* tmpdir in /target/pgo-data
* auto detection of target arch
* plain workload with regular settings
* calling llvm-profdata by absolute path
* testing the client by driving the server